### PR TITLE
fix: loading config files is now operating system independent

### DIFF
--- a/crates/databeam/src/config.rs
+++ b/crates/databeam/src/config.rs
@@ -2,6 +2,7 @@
 use serde::{Deserialize, Serialize};
 use rainbeam_shared::fs;
 use std::io::Result;
+use std::env::current_dir;
 
 /// Configuration file
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -25,10 +26,13 @@ impl Config {
 
     /// Pull configuration file
     pub fn get_config() -> Self {
-        let c = fs::canonicalize(".").unwrap();
-        let here = c.to_str().unwrap();
+        let mut path = current_dir().unwrap();
+        path.push(".config");
+        path.push("databeam");
+        path.push("config.toml");
+        println!("{:?}", path);
 
-        match fs::read(format!("{here}/.config/databeam/config.toml")) {
+        match fs::read(path) {
             Ok(c) => Config::read(c),
             Err(_) => {
                 Self::update_config(Self::default()).expect("failed to write default config");

--- a/crates/rainbeam-core/src/config.rs
+++ b/crates/rainbeam-core/src/config.rs
@@ -1,6 +1,7 @@
 //! Application config manager
 use serde::{Deserialize, Serialize};
 use std::io::Result;
+use std::env::current_dir;
 
 use authbeam::database::HCaptchaConfig;
 use rainbeam_shared::fs;
@@ -119,10 +120,11 @@ impl Config {
 
     /// Pull configuration file
     pub fn get_config() -> Self {
-        let c = fs::canonicalize(".").unwrap();
-        let here = c.to_str().unwrap();
+        let mut path = current_dir().unwrap();
+        path.push(".config");
+        path.push("config.toml");
 
-        match fs::read(format!("{here}/.config/config.toml")) {
+        match fs::read(path) {
             Ok(c) => Config::read(c),
             Err(_) => {
                 Self::update_config(Self::default()).expect("failed to write default config");

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+# set shell := ["pwsh.exe", "-c"] # For development on Windows, using PowerShell
+
 # build release
 build database="sqlite":
     just build-assets


### PR DESCRIPTION
Config files are now accessed through a PathBuf, thus Rainbeam now compiles on any operating system.
The `justfile` has been extended with a line that allows for development on Windows.